### PR TITLE
Cleanup: use css variable for item text color

### DIFF
--- a/WaniKani Item Inspector.user.js
+++ b/WaniKani Item Inspector.user.js
@@ -223,7 +223,6 @@
         };
     };
 
-    var userstyleItemTextColor = $('.subject-character__characters').css('color'); // If the userstyle changes the text color of items, we detect this and use that color
     function table_css(){
         var leechTableCss = `
 
@@ -250,7 +249,7 @@
                 --Wkit-grad-trad-color2: #0d9c0d;
                 --wkit-text-color-light: white;
                 --wkit-text-color-dark: black;
-                --wkit-text-color-item: ${userstyleItemTextColor};
+                --wkit-text-color-item: var(--color-character-text);
                 --wkit-text-color-dark-theme: rgb(188, 188, 188);
                 --wkit-kanji-text-color-dark: hsl(0 0% 18% / 1);
                 --wkit-text-sec-color-light: gainsboro;

--- a/WaniKani Item Inspector.user.js
+++ b/WaniKani Item Inspector.user.js
@@ -223,6 +223,8 @@
         };
     };
 
+	// If the userstyle changes the text color of items without using the provided css variable, we detect this and use that color
+	var userstyleItemTextColor = $('.subject-character__characters').css('color');
     function table_css(){
         var leechTableCss = `
 
@@ -249,7 +251,7 @@
                 --Wkit-grad-trad-color2: #0d9c0d;
                 --wkit-text-color-light: white;
                 --wkit-text-color-dark: black;
-                --wkit-text-color-item: var(--color-character-text);
+                --wkit-text-color-item: var(--color-character-text, ${userstyleItemTextColor}, ${isDarkTheme() ? 'black' : 'white'});
                 --wkit-text-color-dark-theme: rgb(188, 188, 188);
                 --wkit-kanji-text-color-dark: hsl(0 0% 18% / 1);
                 --wkit-text-sec-color-light: gainsboro;


### PR DESCRIPTION
I discovered that there is a Wanikani CSS variable `--color-character-text` that replaces the need for the bit of code I put in that tries to detect the text color used with items and use that throughout Item Inspector's CSS. I have updated the script to use the value from this variable.

Certainly not something that needs to be addressed on its own, perhaps merged in the next time you need to make an update to the script.